### PR TITLE
修复滚动与背景动画的冲突

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,14 @@
 <template>
     <router-view/>
 </template>
+
+<style>
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+}
+</style>

--- a/src/views/Effect.vue
+++ b/src/views/Effect.vue
@@ -12,14 +12,6 @@
     <canvas id="canvas"></canvas>
 </template>
 
-<style>
-:root, body {
-    margin: 0px;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
-}
-</style>
 <style scoped>
 :root, body {
     background: #000;
@@ -45,14 +37,17 @@ button{
 }
 </style>
 <script setup>
-import { onMounted } from 'vue';
+import { onMounted, onUnmounted } from 'vue';
 import { useRoute } from "vue-router";
 const route = useRoute()
 
 onMounted(() => {
+    document.body.style.overflow = 'hidden';
     frame();
-    // console.log(window)
-    // const window = window;
+});
+
+onUnmounted(() => {
+    document.body.style.overflow = '';
 });
 
 function project3D(x, y, z, vars) {
@@ -267,11 +262,11 @@ function frame(vars) {
         var vars = {};
         vars.canvas = document.querySelector("canvas");
         vars.ctx = vars.canvas.getContext("2d");
-        vars.canvas.width = document.body.clientWidth;
-        vars.canvas.height = document.body.clientHeight;
+        vars.canvas.width = window.innerWidth;
+        vars.canvas.height = window.innerHeight;
         window.addEventListener("resize", function () {
-            vars.canvas.width = document.body.clientWidth;
-            vars.canvas.height = document.body.clientHeight;
+            vars.canvas.width = window.innerWidth;
+            vars.canvas.height = window.innerHeight;
             vars.cx = vars.canvas.width / 2;
             vars.cy = vars.canvas.height / 2;
         }, true);

--- a/src/views/NikkeCalc.vue
+++ b/src/views/NikkeCalc.vue
@@ -1,6 +1,6 @@
 <template>
-  <div class="backgr" ref="vantaRef">
-    <div class="content-wrapper">
+  <div class="vanta-bg" ref="vantaRef"></div>
+  <div class="content-wrapper">
       <h1>国服前哨基地资源产出计算器</h1>
 
       <div style="text-align: center; margin-bottom: 20px;">
@@ -197,7 +197,6 @@
           </div>
         </div>
       </div>
-    </div>
   </div>
 </template>
 
@@ -615,13 +614,18 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.backgr {
-  min-height: 100vh;
-  overflow-y: auto;
-  overflow-x: hidden;
+.vanta-bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
 }
 
 .content-wrapper {
+  position: relative;
+  z-index: 1;
   min-height: 100vh;
   padding-bottom: 20px;
 }
@@ -939,11 +943,4 @@ onUnmounted(() => {
   }
 }
 
-:deep(.vanta-canvas) {
-  position: fixed !important;
-  top: 0;
-  left: 0;
-  width: 100% !important;
-  height: 100% !important;
-}
 </style>


### PR DESCRIPTION
- Effect.vue 的全局 overflow:hidden 改为在 onMounted/onUnmounted 中动态设置，避免污染其他路由
- NikkeCalc.vue 将 Vanta 挂载元素从滚动容器中分离为独立的 fixed 层，解决 transform 导致 position:fixed 失效的问题
- Effect.vue canvas 尺寸改用 window.innerWidth/innerHeight，不再依赖 body 的高度
- App.vue 添加全局 margin/padding 重置，修复页面边缘白边

Cowork with Claude